### PR TITLE
Fixed gazebo robot spawn problem

### DIFF
--- a/forkbot/launch/forkbot_gazebo.launch
+++ b/forkbot/launch/forkbot_gazebo.launch
@@ -18,9 +18,9 @@
 </include>
 
 
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find forkbot)/urdf/robot2.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find forkbot)/urdf/forkbot.xacro'"/>
 
-  <node name="forkbot1" pkg="gazebo_ros" type="spawn_model" output="screen"
-     args="-urdf -param forkbot -model forkbot1" />
+  <node name="forkbot_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
+   args="-urdf -param robot_description -model forkbot_robot" />
 
 </launch>

--- a/forkbot/urdf/forkbot.xacro
+++ b/forkbot/urdf/forkbot.xacro
@@ -1,125 +1,154 @@
-<?xml version='1.0'?>
+<?xml version="1.0" encoding="UTF-8"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<!--URDF consist of two main parts: visual and inertial. With only visual part, you can visualize only in Rviz. To spawn the robot in Gazebo, you need the inertial part also -->
 
-  <link name="body">
+<robot name="forkbot_robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <inertial>
-      <mass value="4.4047990875" />
-      <origin xyz="-0.000327 0.000908 0.058457"/>
-      <inertia ixx="0.003000703" ixy="0.000000864" ixz="-0.000011312"
-        iyy="0.002974822" iyz="0.000036294"
-        izz="0.001434739" />
+  <link name='chassis'>
+    <pose>0 0 0.1 0 0 0</pose>
+
+    <inertial>
+      <mass value="15.0"/>
+      <origin xyz="0.0 0 0.1" rpy=" 0 0 0"/>
+      <inertia
+          ixx="0.1" ixy="0" ixz="0"
+          iyy="0.1" iyz="0"
+          izz="0.1"
+      />
     </inertial>
 
-    <visual>
-     <origin xyz="0 0 0" rpy=" 0 0 0"/>
+    <collision name='collision'>
       <geometry>
-       <box size=".4 .2 .1"/>
+        <box size=".4 .2 .1"/>
       </geometry>
-   </visual>
+    </collision>
+
+    <visual name='chassis_visual'>
+      <origin xyz="0 0 0" rpy=" 0 0 0"/>
+      <geometry>
+        <box size=".4 .2 .1"/>
+      </geometry>
+    </visual>
+
+
+    <collision name='caster_collision'>
+      <origin xyz="-0.15 0 -0.05" rpy=" 0 0 0"/>
+      <geometry>
+        <sphere radius="0.05"/>
+      </geometry>
+      <surface>
+        <friction>
+          <ode>
+            <mu>0</mu>
+            <mu2>0</mu2>
+            <slip1>1.0</slip1>
+            <slip2>1.0</slip2>
+          </ode>
+        </friction>
+      </surface>
+    </collision>
+
+    <visual name='caster_visual'>
+      <origin xyz="-0.15 0 -0.05" rpy=" 0 0 0"/>
+      <geometry>
+        <sphere radius="0.05"/>
+      </geometry>
+    </visual>
+
+    <collision name='caster_front_collision'>
+      <origin xyz="0.15 0 -0.05" rpy=" 0 0 0"/>
+      <geometry>
+        <sphere radius="0.05"/>
+      </geometry>
+      <surface>
+        <friction>
+          <ode>
+            <mu>0</mu>
+            <mu2>0</mu2>
+            <slip1>1.0</slip1>
+            <slip2>1.0</slip2>
+          </ode>
+        </friction>
+      </surface>
+    </collision>
+
+    <visual name='caster_front_visual'>
+      <origin xyz="0.15 0 -0.05" rpy=" 0 0 0"/>
+      <geometry>
+        <sphere radius="0.05"/>
+      </geometry>
+    </visual>
 
   </link>
 
-  <joint name="joint1" type="continuous">
-    <parent link="body"/>
-    <child link="armL1"/>
-    <origin xyz="0.15 0.2 0.15" rpy="0 0 0" />
-    <geometry>
-      <cylinder size="0.2 0.5 0.1"/>
-    </geometry>
-    <axis xyz="0 0 0" />
-  </joint>
 
-  <link name="armL1" type="fixed">
-  <visual>
-  <origin rpy="0 0 0" xyz ="0 0 0" />
-    <geometry>
-      <cylinder length="0.3" radius="0.025" />
-    </geometry>
-  </visual>
-  <inertial>
-      <mass value="1.4047990875" />
-      <origin xyz="-0.000327 0.000908 0.058457"/>
-      <inertia ixx="0.003000703" ixy="0.000000864" ixz="-0.000011312"
-        iyy="0.002974822" iyz="0.000036294"
-        izz="0.001434739" />
+  <link name="left_wheel">
+    <!--origin xyz="0.1 0.13 0.1" rpy="0 1.5707 1.5707"/-->
+    <collision name="collision">
+      <origin xyz="0 0 0" rpy="0 1.5707 1.5707"/>
+      <geometry>
+        <cylinder radius="0.1" length="0.05"/>
+      </geometry>
+    </collision>
+    <visual name="left_wheel_visual">
+      <origin xyz="0 0 0" rpy="0 1.5707 1.5707"/>
+      <geometry>
+        <cylinder radius="0.1" length="0.05"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 1.5707 1.5707"/>
+      <mass value="5"/>
+      <inertia
+        ixx=".1" ixy="0.0" ixz="0.0"
+        iyy=".1" iyz="0.0"
+        izz=".1"/>
     </inertial>
   </link>
 
-  <joint name="joint2" type="revolute">
-    <parent link="armL1"/>
-    <child link="armL2"/>
-    <origin xyz="0 0 0" rpy="0 0 0" />
-    <geometry>
-      <cylinder size="0.2 0.5 0.1"/>
-    </geometry>
-    <axis xyz="0 0 0" />
-  </joint>
-
-  <link name="armL2">
-  <visual>
-  <origin rpy="0 0 0" xyz ="0 0 0" />
-    <geometry>
-      <cylinder length="0.3" radius="0.025" />
-    </geometry>
-  </visual>
-  <inertial>
-      <mass value="1.4047990875" />
-      <origin xyz="-0.000327 0.000908 0.058457"/>
-      <inertia ixx="0.003000703" ixy="0.000000864" ixz="-0.000011312"
-        iyy="0.002974822" iyz="0.000036294"
-        izz="0.001434739" />
+  <link name="right_wheel">
+    <!--origin xyz="0.1 -0.13 0.1" rpy="0 1.5707 1.5707"/-->
+    <collision name="collision">
+      <origin xyz="0 0 0" rpy="0 1.5707 1.5707"/>
+      <geometry>
+        <cylinder radius="0.1" length="0.05"/>
+      </geometry>
+    </collision>
+    <visual name="right_wheel_visual">
+      <origin xyz="0 0 0" rpy="0 1.5707 1.5707"/>
+      <geometry>
+        <cylinder radius="0.1" length="0.05"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 1.5707 1.5707"/>
+      <mass value="5"/>
+      <inertia
+        ixx=".1" ixy="0.0" ixz="0.0"
+        iyy=".1" iyz="0.0"
+        izz=".1"/>
     </inertial>
   </link>
 
-  <joint name="joint3" type="revolute">
-    <parent link="armL2"/>
-    <child link="armL3"/>
-    <origin xyz="0 0 0.3" rpy="0 0 0" />
-    <geometry>
-      <cylinder size="0.2 0.5 0.1"/>
-    </geometry>
-    <axis xyz="0 0 0" />
+
+  <joint type="continuous" name="left_wheel_hinge">
+    <origin xyz="0 0.15 0" rpy="0 0 0"/>
+    <!--origin xyz="0.1 0.13 0" rpy="0 1.5707 1.5707"/-->
+    <child link="left_wheel"/>
+    <parent link="chassis"/>
+    <axis xyz="0 1 0" rpy="0 0 0"/>
+    <limit effort="10000" velocity="1000"/>
+    <joint_properties damping="1.0" friction="1.0"/>
   </joint>
 
-  <link name="armL3">
-  <visual>
-  <origin rpy="0 0 0" xyz ="0 0 0" />
-    <geometry>
-      <cylinder length="0.3" radius="0.025" />
-    </geometry>
-  </visual>
-  <inertial>
-      <mass value="1.4047990875" />
-      <origin xyz="-0.000327 0.000908 0.058457"/>
-      <inertia ixx="0.003000703" ixy="0.000000864" ixz="-0.000011312"
-        iyy="0.002974822" iyz="0.000036294"
-        izz="0.001434739" />
-    </inertial>
-  </link>
-
-  <joint name="joint4" type="revolute">
-    <parent link="armL3"/>
-    <child link="fork"/>
-    <origin xyz="0 0 0.3" rpy="0 0 0" />
-    <axis xyz="0 0 0" />
+  <joint type="continuous" name="right_wheel_hinge">
+    <origin xyz="0 -0.15 0" rpy="0 0 0"/>
+    <!--origin xyz="0.1 -0.13 0" rpy="0 1.5707 1.5707"/-->
+    <child link="right_wheel"/>
+    <parent link="chassis"/>
+    <axis xyz="0 1 0" rpy="0 0 0"/>
+    <limit effort="10000" velocity="1000"/>
+    <joint_properties damping="1.0" friction="1.0"/>
   </joint>
-
-  <link name="fork">
-  <visual>
-  <origin rpy="0 0 0" xyz ="0 0 0" />
-    <geometry>
-      <box size="0.1 0.1 0.1" />
-    </geometry>
-  </visual>
-  <inertial>
-      <mass value="1.4047990875" />
-      <origin xyz="-0.000327 0.000908 0.058457"/>
-      <inertia ixx="0.003000703" ixy="0.000000864" ixz="-0.000011312"
-        iyy="0.002974822" iyz="0.000036294"
-        izz="0.001434739" />
-    </inertial>
-  </link>
 
 </robot>


### PR DESCRIPTION
The problem was that first in the launch file, the robot spawner was called wrong. That is fixed but the robot didn't appeared in Gazebo. This lead to the second problem which is that the inertial part in the URDF file was missing. (URDF consist of two main parts: visual and inertial. With only visual part, you can visualize only in Rviz. To spawn the robot in Gazebo, you need the inertial part also). I took it from the mybot_description. You can make your robot model changes on forkbot.xacro now.